### PR TITLE
Update badges and repo links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,10 @@
 = Address Book (Level 4)
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/se-edu/addressbook-level4[image:https://travis-ci.org/se-edu/addressbook-level4.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/damithc/addressbook-level4[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
-https://coveralls.io/github/se-edu/addressbook-level4?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master[Coverage Status]]
-https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level4&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
-https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]
+https://travis-ci.org/CS2103JAN2018-F14-B4/main[image:https://travis-ci.org/CS2103JAN2018-F14-B4/main.svg?branch=master[Build Status]]
+https://ci.appveyor.com/project/takuyakanbr/main[image:https://ci.appveyor.com/api/projects/status/0b9xn6cwd3i8a80b?svg=true[Build status]]
+https://coveralls.io/github/CS2103JAN2018-F14-B4/main?branch=master[image:https://coveralls.io/repos/github/CS2103JAN2018-F14-B4/main/badge.svg?branch=master[Coverage Status]]
+https://www.codacy.com/app/takuyakanbr/main[image:https://api.codacy.com/project/badge/Grade/aa9140dcebbd474c9dc16c57fe247e78[Codacy Badge]]
 
 ifdef::env-github[]
 image::docs/images/Ui.png[width="600"]

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -10,9 +10,9 @@ ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
 endif::[]
-:repoURL: https://github.com/se-edu/addressbook-level4/tree/master
+:repoURL: https://github.com/CS2103JAN2018-F14-B4/main/tree/master
 
-By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
+By: `Team F14-B4`      Since: `Jan 2018`      Licence: `MIT`
 
 == Setting up
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -11,9 +11,9 @@ ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
 endif::[]
-:repoURL: https://github.com/se-edu/addressbook-level4
+:repoURL: https://github.com/CS2103JAN2018-F14-B4/main
 
-By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
+By: `Team F14-B4`      Since: `Jan 2018`      Licence: `MIT`
 
 == Introduction
 


### PR DESCRIPTION
* Update the links and image urls of badges for Travis, Coveralls, Appveyor, and Codacy.
* Remove Gitter badge in README.
* Update repoURL in UserGuide and DeveloperGuide.