### PR TITLE
Keep the ordering of authors and categories as per original API data

### DIFF
--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -2,10 +2,12 @@ package seedu.address.commons.util;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -51,11 +53,11 @@ public class CollectionUtil {
     }
 
     /**
-     * Returns a new {@link Set} containing all the specified items.
+     * Returns a new {@link List} containing all the specified items.
      */
     @SafeVarargs
-    public static <T> Set<T> toSet(T... items) {
-        HashSet<T> set = new HashSet<>();
+    public static <T> List<T> toList(T... items) {
+        ArrayList<T> set = new ArrayList<>();
         Collections.addAll(set, items);
         return set;
     }

--- a/src/main/java/seedu/address/model/UniqueList.java
+++ b/src/main/java/seedu/address/model/UniqueList.java
@@ -8,9 +8,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.logging.Logger;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DuplicateDataException;
 import seedu.address.commons.util.CollectionUtil;
 
@@ -20,6 +22,8 @@ import seedu.address.commons.util.CollectionUtil;
  * Supports minimal set of list operations for the app's features.
  */
 public class UniqueList<T> implements Iterable<T> {
+
+    private static final Logger logger = LogsCenter.getLogger(UniqueList.class);
 
     protected final ObservableList<T> internalList = FXCollections.observableArrayList();
 
@@ -94,7 +98,7 @@ public class UniqueList<T> implements Iterable<T> {
             try {
                 add(toAdd);
             } catch (DuplicateDataException e) {
-                e.printStackTrace();
+                logger.fine("Duplicate data: " + toAdd);
             }
         }
         assert CollectionUtil.elementsAreUnique(internalList);

--- a/src/main/java/seedu/address/model/UniqueList.java
+++ b/src/main/java/seedu/address/model/UniqueList.java
@@ -3,9 +3,11 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Set;
+import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -27,31 +29,23 @@ public class UniqueList<T> implements Iterable<T> {
     public UniqueList() {}
 
     /**
-     * Creates a UniqueList using given set.
-     * Enforces no nulls.
+     * Returns all items in this list as a list.
+     * This list is mutable and change-insulated against the internal list.
      */
-    public UniqueList(Set<T> items) {
-        requireAllNonNull(items);
-        internalList.addAll(items);
-
+    public List<T> toList() {
         assert CollectionUtil.elementsAreUnique(internalList);
+        return new ArrayList<>(internalList);
     }
 
     /**
-     * Returns all items in this list as a Set.
-     * This set is mutable and change-insulated against the internal list.
+     * Replaces the items in this list with those in the given collection.
      */
-    public Set<T> toSet() {
-        assert CollectionUtil.elementsAreUnique(internalList);
-        return new HashSet<>(internalList);
-    }
-
-    /**
-     * Replaces the items in this list with those in the argument list.
-     */
-    public void setItems(Set<T> items) {
+    public void setItems(Collection<T> items) throws DuplicateDataException {
         requireAllNonNull(items);
-        internalList.setAll(items);
+        internalList.clear();
+        for (T toAdd : items) {
+            add(toAdd);
+        }
         assert CollectionUtil.elementsAreUnique(internalList);
     }
 
@@ -59,7 +53,7 @@ public class UniqueList<T> implements Iterable<T> {
      * Ensures every item in the argument list exists in this object.
      */
     public void mergeFrom(UniqueList<T> from) {
-        final Set<T> alreadyInside = this.toSet();
+        final List<T> alreadyInside = this.toList();
         from.internalList.stream()
                 .filter(tag -> !alreadyInside.contains(tag))
                 .forEach(internalList::add);
@@ -87,6 +81,22 @@ public class UniqueList<T> implements Iterable<T> {
         }
         internalList.add(toAdd);
 
+        assert CollectionUtil.elementsAreUnique(internalList);
+    }
+
+    /**
+     * Adds all items in the given collection into this list.
+     * Any duplicates found will be ignored.
+     */
+    public void addAllIgnoresDuplicates(Collection<T> items) {
+        requireAllNonNull(items);
+        for (T toAdd : items) {
+            try {
+                add(toAdd);
+            } catch (DuplicateDataException e) {
+                e.printStackTrace();
+            }
+        }
         assert CollectionUtil.elementsAreUnique(internalList);
     }
 

--- a/src/main/java/seedu/address/model/book/Book.java
+++ b/src/main/java/seedu/address/model/book/Book.java
@@ -2,9 +2,10 @@ package seedu.address.model.book;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import seedu.address.model.UniqueList;
 
@@ -29,8 +30,9 @@ public class Book {
     /**
      * Creates a {@code Book} with the default status, priority, and rating.
      * Every field must be present and not null.
+     * Duplicate authors and categories will be silently ignored.
      */
-    public Book(Gid gid, Isbn isbn, Set<Author> authors, Title title, Set<Category> categories,
+    public Book(Gid gid, Isbn isbn, Collection<Author> authors, Title title, Collection<Category> categories,
                 Description description, Publisher publisher, PublicationDate publicationDate) {
         this(gid, isbn, authors, title, categories, description, Status.DEFAULT_STATUS,
                 Priority.DEFAULT_PRIORITY, new Rating(), publisher, publicationDate);
@@ -39,17 +41,20 @@ public class Book {
     /**
      * Creates a {@code Book}.
      * Every field must be present and not null.
+     * Duplicate authors and categories will be silently ignored.
      */
-    public Book(Gid gid, Isbn isbn, Set<Author> authors, Title title, Set<Category> categories,
+    public Book(Gid gid, Isbn isbn, Collection<Author> authors, Title title, Collection<Category> categories,
                 Description description, Status status, Priority priority, Rating rating,
                 Publisher publisher, PublicationDate publicationDate) {
         requireAllNonNull(gid, isbn, authors, title, categories, description,
                 status, priority, rating, publisher, publicationDate);
         this.gid = gid;
         this.isbn = isbn;
-        this.authors = new UniqueList<>(authors);
+        this.authors = new UniqueList<>();
+        this.authors.addAllIgnoresDuplicates(authors);
         this.title = title;
-        this.categories = new UniqueList<>(categories);
+        this.categories = new UniqueList<>();
+        this.categories.addAllIgnoresDuplicates(categories);
         this.description = description;
         this.status = status;
         this.priority = priority;
@@ -59,11 +64,11 @@ public class Book {
     }
 
     /**
-     * Returns an immutable authors set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable authors list, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
-    public Set<Author> getAuthors() {
-        return Collections.unmodifiableSet(authors.toSet());
+    public List<Author> getAuthors() {
+        return Collections.unmodifiableList(authors.toList());
     }
 
     public Title getTitle() {
@@ -71,11 +76,11 @@ public class Book {
     }
 
     /**
-     * Returns an immutable categories set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable categories list, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
-    public Set<Category> getCategories() {
-        return Collections.unmodifiableSet(categories.toSet());
+    public List<Category> getCategories() {
+        return Collections.unmodifiableList(categories.toList());
     }
 
     public Description getDescription() {

--- a/src/main/java/seedu/address/model/util/BookDataUtil.java
+++ b/src/main/java/seedu/address/model/util/BookDataUtil.java
@@ -1,7 +1,7 @@
 package seedu.address.model.util;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import seedu.address.model.book.Author;
 import seedu.address.model.book.Category;
@@ -12,10 +12,10 @@ import seedu.address.model.book.Category;
 public class BookDataUtil {
 
     /**
-     * Returns an author set containing the list of strings given.
+     * Returns an author list containing the list of strings given.
      */
-    public static Set<Author> getAuthorSet(String... strings) {
-        HashSet<Author> authors = new HashSet<>();
+    public static List<Author> getAuthorList(String... strings) {
+        ArrayList<Author> authors = new ArrayList<>();
         for (String s : strings) {
             authors.add(new Author(s));
         }
@@ -24,10 +24,10 @@ public class BookDataUtil {
     }
 
     /**
-     * Returns a category set containing the list of strings given.
+     * Returns a category list containing the list of strings given.
      */
-    public static Set<Category> getCategorySet(String... strings) {
-        HashSet<Category> categories = new HashSet<>();
+    public static List<Category> getCategoryList(String... strings) {
+        ArrayList<Category> categories = new ArrayList<>();
         for (String s : strings) {
             categories.add(new Category(s));
         }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -27,27 +27,30 @@ public final class SampleDataUtil {
 
     private static final Book ARTEMIS = new Book(new Gid("ry3GjwEACAAJ"), new Isbn("9780525572664"),
             Collections.singleton(new Author("Andy Weir")), new Title("Artemis"),
-            CollectionUtil.toSet(new Category("Fiction"), new Category("Science Fiction")),
+            CollectionUtil.toList(new Category("Fiction"), new Category("Science Fiction")),
             new Description("This is Artemis."), Status.READ, Priority.LOW, new Rating(5),
             new Publisher(""), new PublicationDate("2017-11-14"));
     private static final Book BABYLON_ASHES = new Book(new Gid("3jsYCwAAQBAJ"), new Isbn("9780316217637"),
             Collections.singleton(new Author("James S. A. Corey")), new Title("Babylon's Ashes"),
-            CollectionUtil.toSet(new Category("Fiction"), new Category("Science Fiction"), new Category("Space Opera")),
+            CollectionUtil.toList(new Category("Fiction"), new Category("Science Fiction"),
+                    new Category("Space Opera")),
             new Description("This is Babylon's Ashes."), Status.READING, Priority.HIGH, new Rating(4),
             new Publisher("Orbit"), new PublicationDate("2016-12-06"));
     private static final Book COLLAPSING_EMPIRE = new Book(new Gid("2SoaDAAAQBAJ"), new Isbn("9780765388896"),
             Collections.singleton(new Author("John Scalzi")), new Title("The Collapsing Empire"),
-            CollectionUtil.toSet(new Category("Fiction"), new Category("Science Fiction"), new Category("Space Opera")),
+            CollectionUtil.toList(new Category("Fiction"), new Category("Science Fiction"),
+                    new Category("Space Opera")),
             new Description("This is Collapsing Empire."), Status.READING, Priority.LOW, new Rating(-1),
             new Publisher("Tor Books"), new PublicationDate("2017-03-21"));
     private static final Book CONSIDER_PHLEBAS = new Book(new Gid("3_bJKlAOecEC"), new Isbn("9780316095839"),
             Collections.singleton(new Author("Iain M. Banks")), new Title("Consider Phlebas"),
-            CollectionUtil.toSet(new Category("Fiction"), new Category("Science Fiction"), new Category("Space Opera")),
+            CollectionUtil.toList(new Category("Fiction"), new Category("Science Fiction"),
+                    new Category("Space Opera")),
             new Description("This is Consider Phlebas."), Status.UNREAD, Priority.NONE, new Rating(-1),
                 new Publisher("Orbit"), new PublicationDate("2009-12-01"));
     private static final Book WAKING_GODS = new Book(new Gid("CIj1DAAAQBAJ"), new Isbn("9781405921909"),
             Collections.singleton(new Author("Sylvain Neuvel")), new Title("Waking Gods"),
-            CollectionUtil.toSet(new Category("Fiction"), new Category("Science Fiction")),
+            CollectionUtil.toList(new Category("Fiction"), new Category("Science Fiction")),
             new Description("This is Waking Gods."), Status.UNREAD, Priority.NONE, new Rating(-1),
             new Publisher("Penguin UK"), new PublicationDate("2017-04-06"));
 

--- a/src/main/java/seedu/address/network/api/google/JsonBookDetails.java
+++ b/src/main/java/seedu/address/network/api/google/JsonBookDetails.java
@@ -1,6 +1,6 @@
 package seedu.address.network.api.google;
 
-import java.util.Set;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -48,8 +48,8 @@ public class JsonBookDetails {
         }
 
         return new Book(new Gid(id), isbn,
-                BookDataUtil.getAuthorSet(volumeInfo.authors), new Title(volumeInfo.title),
-                getCategorySet(volumeInfo.categories), new Description(volumeInfo.description),
+                BookDataUtil.getAuthorList(volumeInfo.authors), new Title(volumeInfo.title),
+                getCategoryList(volumeInfo.categories), new Description(volumeInfo.description),
                 new Publisher(volumeInfo.publisher),
                 new PublicationDate(volumeInfo.publishedDate));
     }
@@ -62,11 +62,11 @@ public class JsonBookDetails {
                 .orElse(null);
     }
 
-    private static Set<Category> getCategorySet(String[] categories) {
+    private static List<Category> getCategoryList(String[] categories) {
         return Stream.of(categories)
                 .flatMap(category -> Stream.of(category.split("/")))
                 .map(token -> new Category(token.trim()))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 
     /** Temporary data holder used for deserialization. */

--- a/src/main/java/seedu/address/network/api/google/JsonSearchResults.java
+++ b/src/main/java/seedu/address/network/api/google/JsonSearchResults.java
@@ -71,8 +71,8 @@ public class JsonSearchResults {
         }
 
         return new Book(new Gid(volume.id), isbn,
-                BookDataUtil.getAuthorSet(volumeInfo.authors), new Title(volumeInfo.title),
-                BookDataUtil.getCategorySet(volumeInfo.categories), new Description(volumeInfo.description),
+                BookDataUtil.getAuthorList(volumeInfo.authors), new Title(volumeInfo.title),
+                BookDataUtil.getCategoryList(volumeInfo.categories), new Description(volumeInfo.description),
                 new Publisher(volumeInfo.publisher), new PublicationDate(volumeInfo.publishedDate));
     }
 

--- a/src/main/java/seedu/address/storage/XmlAdaptedBook.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedBook.java
@@ -1,7 +1,6 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -175,7 +174,7 @@ public class XmlAdaptedBook {
         }
         final PublicationDate publicationDate = new PublicationDate(this.publicationDate);
 
-        return new Book(gid, isbn, new HashSet<>(bookAuthors), title, new HashSet<>(bookCategories),
+        return new Book(gid, isbn, bookAuthors, title, bookCategories,
                 description, status, priority, rating, publisher, publicationDate);
     }
 

--- a/src/test/java/seedu/address/model/UniqueListTest.java
+++ b/src/test/java/seedu/address/model/UniqueListTest.java
@@ -2,7 +2,8 @@ package seedu.address.model;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,7 +22,7 @@ public class UniqueListTest {
         uniqueList.add(new Category("Cat 1"));
         uniqueList.add(new Category("Cat 2"));
         uniqueList.add(new Category("Cat 3"));
-        assertEquals(3, uniqueList.toSet().size());
+        assertEquals(3, uniqueList.toList().size());
     }
 
     @Test
@@ -41,14 +42,44 @@ public class UniqueListTest {
     }
 
     @Test
+    public void addAllIgnoresDuplicates_validItems_success() {
+        UniqueList<Category> uniqueList = new UniqueList<>();
+        ArrayList<Category> toAdd = new ArrayList<>();
+        toAdd.add(new Category("Cat 1"));
+        toAdd.add(new Category("Cat 2"));
+        uniqueList.addAllIgnoresDuplicates(toAdd);
+        assertEquals(2, uniqueList.toList().size());
+    }
+
+    @Test
+    public void addAllIgnoresDuplicates_duplicateItems_success() {
+        UniqueList<Category> uniqueList = new UniqueList<>();
+        ArrayList<Category> toAdd = new ArrayList<>();
+        toAdd.add(new Category("Cat 1"));
+        toAdd.add(new Category("Cat 2"));
+        toAdd.add(new Category("Cat 2"));
+        toAdd.add(new Category("Cat 3"));
+        toAdd.add(new Category("Cat 1"));
+        uniqueList.addAllIgnoresDuplicates(toAdd);
+        assertEquals(3, uniqueList.toList().size());
+    }
+
+    @Test
+    public void addAllIgnoresDuplicates_null_throwsNullPointerException() {
+        UniqueList<Category> uniqueList = new UniqueList<>();
+        thrown.expect(NullPointerException.class);
+        uniqueList.addAllIgnoresDuplicates(null);
+    }
+
+    @Test
     public void toSet_modifyList_doesNotMutateList() throws Exception {
         UniqueList<Category> uniqueList = new UniqueList<>();
         uniqueList.add(new Category("Cat 1"));
-        Set<Category> set = uniqueList.toSet();
+        List<Category> set = uniqueList.toList();
         set.add(new Category("Cat 2"));
-        assertEquals(1, uniqueList.toSet().size());
+        assertEquals(1, uniqueList.toList().size());
         set.remove(new Category("Cat 1"));
-        assertEquals(1, uniqueList.toSet().size());
+        assertEquals(1, uniqueList.toList().size());
     }
 
     @Test
@@ -58,14 +89,14 @@ public class UniqueListTest {
         UniqueList<Category> replacement = new UniqueList<>();
         replacement.add(new Category("Cat 2"));
         replacement.add(new Category("Cat 3"));
-        uniqueList.setItems(replacement.toSet());
-        assertEquals(2, uniqueList.toSet().size());
+        uniqueList.setItems(replacement.toList());
+        assertEquals(2, uniqueList.toList().size());
         assertEquals(true, uniqueList.contains(new Category("Cat 2")));
         assertEquals(false, uniqueList.contains(new Category("Cat 1")));
     }
 
     @Test
-    public void setItems_null_throwsNullPointerException() {
+    public void setItems_null_throwsNullPointerException() throws Exception {
         UniqueList<Category> uniqueList = new UniqueList<>();
         thrown.expect(NullPointerException.class);
         uniqueList.setItems(null);
@@ -79,7 +110,7 @@ public class UniqueListTest {
         toMerge.add(new Category("Cat 2"));
         toMerge.add(new Category("Cat 3"));
         uniqueList.mergeFrom(toMerge);
-        assertEquals(3, uniqueList.toSet().size());
+        assertEquals(3, uniqueList.toList().size());
         assertEquals(true, uniqueList.contains(new Category("Cat 2")));
         assertEquals(true, uniqueList.contains(new Category("Cat 1")));
     }

--- a/src/test/java/seedu/address/model/book/BookTest.java
+++ b/src/test/java/seedu/address/model/book/BookTest.java
@@ -14,47 +14,47 @@ public class BookTest {
                 null, null, null, null, null, null, null, null, null));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(null, new Isbn(""),
-                Collections.emptySet(), new Title(""), Collections.emptySet(),
+                Collections.emptyList(), new Title(""), Collections.emptyList(),
                 new Description(""), new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), null,
-                Collections.emptySet(), new Title(""), Collections.emptySet(),
+                Collections.emptyList(), new Title(""), Collections.emptyList(),
                 new Description(""), new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                null, new Title(""), Collections.emptySet(),
+                null, new Title(""), Collections.emptyList(),
                 new Description(""), new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), null, Collections.emptySet(),
+                Collections.emptyList(), null, Collections.emptyList(),
                 new Description(""), new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), new Title(""), null,
+                Collections.emptyList(), new Title(""), null,
                 new Description(""), new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), new Title(""), Collections.emptySet(),
+                Collections.emptyList(), new Title(""), Collections.emptyList(),
                 null, new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), new Title(""), Collections.emptySet(), new Description(""),
+                Collections.emptyList(), new Title(""), Collections.emptyList(), new Description(""),
                 null, Priority.LOW, new Rating(-1), new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), new Title(""), Collections.emptySet(), new Description(""),
+                Collections.emptyList(), new Title(""), Collections.emptyList(), new Description(""),
                 Status.READ, null, new Rating(-1), new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), new Title(""), Collections.emptySet(), new Description(""),
+                Collections.emptyList(), new Title(""), Collections.emptyList(), new Description(""),
                 Status.READ, Priority.LOW, null, new Publisher(""), new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), new Title(""), Collections.emptySet(),
+                Collections.emptyList(), new Title(""), Collections.emptyList(),
                 new Description(""), null, new PublicationDate("")));
 
         Assert.assertThrows(NullPointerException.class, () -> new Book(new Gid(""), new Isbn(""),
-                Collections.emptySet(), new Title(""), Collections.emptySet(),
+                Collections.emptyList(), new Title(""), Collections.emptyList(),
                 new Description(""), new Publisher(""), null));
     }
 

--- a/src/test/java/seedu/address/model/book/UniqueBookListTest.java
+++ b/src/test/java/seedu/address/model/book/UniqueBookListTest.java
@@ -61,7 +61,7 @@ public class UniqueBookListTest {
         UniqueBookList uniqueBookList = new UniqueBookList();
         uniqueBookList.add(TypicalBooks.ARTEMIS);
         uniqueBookList.remove(TypicalBooks.ARTEMIS);
-        assertEquals(0, uniqueBookList.toSet().size());
+        assertEquals(0, uniqueBookList.toList().size());
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/BookBuilder.java
+++ b/src/test/java/seedu/address/testutil/BookBuilder.java
@@ -1,7 +1,7 @@
 package seedu.address.testutil;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import seedu.address.model.book.Author;
 import seedu.address.model.book.Book;
@@ -31,9 +31,9 @@ public class BookBuilder {
     private static final String DEFAULT_PUBLISHER = "Someone";
     private static final String DEFAULT_PUBLICATION_DATE = "2017-11-14";
 
-    private Set<Author> authors;
+    private List<Author> authors;
     private Title title;
-    private Set<Category> categories;
+    private List<Category> categories;
     private Description description;
     private Status status;
     private Priority priority;
@@ -44,9 +44,9 @@ public class BookBuilder {
     private Publisher publisher;
 
     public BookBuilder() {
-        authors = Collections.singleton(new Author(DEFAULT_AUTHOR));
+        authors = Collections.singletonList(new Author(DEFAULT_AUTHOR));
         title = new Title(DEFAULT_TITLE);
-        categories = Collections.singleton(new Category(DEFAULT_CATEGORY));
+        categories = Collections.singletonList(new Category(DEFAULT_CATEGORY));
         description = new Description(DEFAULT_DESCRIPTION);
         status = Status.DEFAULT_STATUS;
         priority = Priority.DEFAULT_PRIORITY;
@@ -75,7 +75,7 @@ public class BookBuilder {
      * Parses the {@code authors} into a {@code Set<Author>} and set it to the {@code Book} that we are building.
      */
     public BookBuilder withAuthors(String... authors) {
-        this.authors = BookDataUtil.getAuthorSet(authors);
+        this.authors = BookDataUtil.getAuthorList(authors);
         return this;
     }
 
@@ -91,7 +91,7 @@ public class BookBuilder {
      * Parses the {@code categories} into a {@code Set<Category>} and set it to the {@code Book} that we are building.
      */
     public BookBuilder withCategories(String... categories) {
-        this.categories = BookDataUtil.getCategorySet(categories);
+        this.categories = BookDataUtil.getCategoryList(categories);
         return this;
     }
 


### PR DESCRIPTION
* Use lists instead of sets to store authors and categories.
* Update Book constructor to accept Collection instead of Set of authors and categories.